### PR TITLE
[fix] 각 페이지 공통 테이블 구조 적용 및 outlet 추가하여 자식 라우트 렌더링

### DIFF
--- a/src/components/WineDetailContent.tsx
+++ b/src/components/WineDetailContent.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { WineDataTypes } from "../../types/CommonTypes";
+import { WineDataTypes } from "./../types/CommonTypes";
 import { useState } from "react";
 
 export default function WineDetailContent() {

--- a/src/components/common/MainImageSlider.tsx
+++ b/src/components/common/MainImageSlider.tsx
@@ -1,3 +1,4 @@
+/*
 import styled from "styled-components";
 import { useEffect, useState } from "react";
 
@@ -11,3 +12,4 @@ export default function MainImageSlider() {
   });
   return <div></div>;
 }
+*/

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -1,14 +1,18 @@
 import styled from "styled-components";
-import { WineRow } from "../../types/CommonTypes";
-import { renderCell } from "../../utils/renderCell";
 
-interface TableProps {
+interface TableProps<T extends { id: string }> {
   columns: string[];
-  data: WineRow[];
+  data: T[];
   onRowClick?: (id: string) => void;
+  renderCell: (row: T, column: string) => React.ReactNode;
 }
 
-export default function Table({ columns, data, onRowClick }: TableProps) {
+export default function Table<T extends { id: string }>({
+  columns,
+  data,
+  onRowClick,
+  renderCell,
+}: TableProps<T>) {
   return (
     <Container>
       <TableRow>

--- a/src/constants/constants.tsx
+++ b/src/constants/constants.tsx
@@ -16,5 +16,4 @@ export const userColumns = [
   "회원 상태",
   "가입일",
   "정지 마감일",
-  "-",
 ];

--- a/src/constants/constants.tsx
+++ b/src/constants/constants.tsx
@@ -4,6 +4,7 @@ export const wineColumns = [
   "종류",
   "지역",
   "생산지(국가)",
+  "품종",
   "등록일",
 ];
 

--- a/src/constants/constants.tsx
+++ b/src/constants/constants.tsx
@@ -17,3 +17,14 @@ export const userColumns = [
   "가입일",
   "정지 마감일",
 ];
+
+export const reportColumns = [
+  "접수 번호",
+  "신고 날짜",
+  "신고자 ID",
+  "신고대상 ID",
+  "신고내용",
+  "처리상태",
+  "처리 완료일",
+  "처리결과",
+];

--- a/src/pages/report/CompletedReportPage.tsx
+++ b/src/pages/report/CompletedReportPage.tsx
@@ -1,44 +1,54 @@
+import { useState } from "react";
 import styled from "styled-components";
 import DetailHeader from "../../components/common/Header/DetailHeader";
 import SideBar from "../../components/common/SideBar";
 import SearchBox from "../../components/common/SearchBox";
 import Table from "../../components/common/Table";
-import { UserDataTypes } from "../../types/CommonTypes";
 import AdminHeader from "../../components/common/Header/AdminHeader";
+import { reportColumns } from "../../constants/constants";
+import { ReportRow } from "../../types/CommonTypes";
+import { renderReportCell } from "../../utils/renderReportCell";
+import { formatDate } from "../../utils/formatDate";
 
 export default function CompletedReportPage() {
-  const columns = [
-    "접수 번호",
-    "신고 날짜",
-    "신고자 ID",
-    "신고대상 ID",
-    "신고내용",
-    "처리상태",
-    "처리 완료일",
-    "처리결과",
-  ];
-  const data: UserDataTypes[] = [
+  const fieldNames = ["reporter", "reported"];
+  const [searchParams, setSearchParams] = useState({
+    reporter: "",
+    reported: "",
+  });
+  // const [searchTrigger, setSearchTrigger] = useState(0);
+
+  const data: ReportRow[] = [
     {
-      id: "C011123",
-      name: "위승주",
-      userId: "wsj11029",
-      phone: "010-3655-5641",
-      status: "정상",
-      joinDate: "2024-09-03",
-      banEndDate: "-",
-      action: "-",
+      id: "011",
+      reportDate: "2024-11-13",
+      reporterId: "wsj11029",
+      reportedId: "oyatplum",
+      content: "노쇼 신고",
+      status: "처리 전",
+      completedDate: "-",
+      result: "-",
     },
     {
-      id: "C011124",
-      name: "김철수",
-      userId: "kimcs99",
-      phone: "010-2222-3333",
-      status: "정상",
-      joinDate: "2024-07-01",
-      banEndDate: "-",
-      action: "-",
+      id: "042",
+      reportDate: "2024-11-24",
+      reporterId: "wsj11029",
+      reportedId: "kimjuns00",
+      content: "노쇼 신고",
+      status: "처리 전",
+      completedDate: "-",
+      result: "-",
     },
   ];
+
+  const handleInputChange = (index: number, value: string) => {
+    const key = fieldNames[index];
+    setSearchParams((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSearchClick = () => {
+    // 나중에 API 트리거 연동
+  };
 
   return (
     <Container>
@@ -54,8 +64,22 @@ export default function CompletedReportPage() {
           ]}
         />
         <InnerContainer>
-          <SearchBox titles={["신고자 :", "신고 대상 :"]} />
-          <Table columns={columns} data={data} />
+          <SearchBox
+            titles={["신고자 :", "신고 대상 :"]}
+            inputValues={fieldNames.map(
+              (name) => searchParams[name as keyof typeof searchParams]
+            )}
+            onInputChange={handleInputChange}
+            onSearchClick={handleSearchClick}
+          />
+          <Table
+            columns={reportColumns}
+            data={data.map((row) => ({
+              ...row,
+              createdAt: formatDate(row.completedDate),
+            }))}
+            renderCell={renderReportCell}
+          />
         </InnerContainer>
       </ContentContainer>
     </Container>

--- a/src/pages/report/NoshowReportPage.tsx
+++ b/src/pages/report/NoshowReportPage.tsx
@@ -1,44 +1,54 @@
+import { useState } from "react";
 import styled from "styled-components";
 import DetailHeader from "../../components/common/Header/DetailHeader";
 import SideBar from "../../components/common/SideBar";
 import SearchBox from "../../components/common/SearchBox";
 import Table from "../../components/common/Table";
-import { UserDataTypes } from "../../types/CommonTypes";
 import AdminHeader from "../../components/common/Header/AdminHeader";
+import { reportColumns } from "../../constants/constants";
+import { ReportRow } from "../../types/CommonTypes";
+import { renderReportCell } from "../../utils/renderReportCell";
+import { formatDate } from "../../utils/formatDate";
 
 export default function NoshowReportPage() {
-  const columns = [
-    "접수 번호",
-    "신고 날짜",
-    "신고자 ID",
-    "신고대상 ID",
-    "신고내용",
-    "처리상태",
-    "처리 완료일",
-    "처리결과",
-  ];
-  const data: UserDataTypes[] = [
+  const fieldNames = ["reporter", "reported"];
+  const [searchParams, setSearchParams] = useState({
+    reporter: "",
+    reported: "",
+  });
+  // const [searchTrigger, setSearchTrigger] = useState(0);
+
+  const data: ReportRow[] = [
     {
-      id: "C011123",
-      name: "위승주",
-      userId: "wsj11029",
-      phone: "010-3655-5641",
-      status: "정상",
-      joinDate: "2024-09-03",
-      banEndDate: "-",
-      action: "-",
+      id: "011",
+      reportDate: "2024-11-13",
+      reporterId: "wsj11029",
+      reportedId: "oyatplum",
+      content: "노쇼 신고",
+      status: "처리 전",
+      completedDate: "-",
+      result: "-",
     },
     {
-      id: "C011124",
-      name: "김철수",
-      userId: "kimcs99",
-      phone: "010-2222-3333",
-      status: "정상",
-      joinDate: "2024-07-01",
-      banEndDate: "-",
-      action: "-",
+      id: "042",
+      reportDate: "2024-11-24",
+      reporterId: "wsj11029",
+      reportedId: "kimjuns00",
+      content: "노쇼 신고",
+      status: "처리 전",
+      completedDate: "-",
+      result: "-",
     },
   ];
+
+  const handleInputChange = (index: number, value: string) => {
+    const key = fieldNames[index];
+    setSearchParams((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSearchClick = () => {
+    // 나중에 API 트리거 연동
+  };
 
   return (
     <Container>
@@ -54,8 +64,22 @@ export default function NoshowReportPage() {
           ]}
         />
         <InnerContainer>
-          <SearchBox titles={["신고자 :", "신고 대상 :"]} />
-          <Table columns={columns} data={data} />
+          <SearchBox
+            titles={["신고자 :", "신고 대상 :"]}
+            inputValues={fieldNames.map(
+              (name) => searchParams[name as keyof typeof searchParams]
+            )}
+            onInputChange={handleInputChange}
+            onSearchClick={handleSearchClick}
+          />
+          <Table
+            columns={reportColumns}
+            data={data.map((row) => ({
+              ...row,
+              createdAt: formatDate(row.completedDate),
+            }))}
+            renderCell={renderReportCell}
+          />
         </InnerContainer>
       </ContentContainer>
     </Container>

--- a/src/pages/report/ReportPage.tsx
+++ b/src/pages/report/ReportPage.tsx
@@ -1,44 +1,54 @@
+import { useState } from "react";
 import styled from "styled-components";
 import DetailHeader from "../../components/common/Header/DetailHeader";
 import SideBar from "../../components/common/SideBar";
 import SearchBox from "../../components/common/SearchBox";
 import Table from "../../components/common/Table";
-import { UserDataTypes } from "../../types/CommonTypes";
 import AdminHeader from "../../components/common/Header/AdminHeader";
+import { reportColumns } from "../../constants/constants";
+import { ReportRow } from "../../types/CommonTypes";
+import { renderReportCell } from "../../utils/renderReportCell";
+import { formatDate } from "../../utils/formatDate";
 
 export default function ReportPage() {
-  const columns = [
-    "접수 번호",
-    "신고 날짜",
-    "신고자 ID",
-    "신고대상 ID",
-    "신고내용",
-    "처리상태",
-    "처리 완료일",
-    "처리결과",
-  ];
-  const data: UserDataTypes[] = [
+  const fieldNames = ["reporter", "reported"];
+  const [searchParams, setSearchParams] = useState({
+    reporter: "",
+    reported: "",
+  });
+  // const [searchTrigger, setSearchTrigger] = useState(0);
+
+  const data: ReportRow[] = [
     {
-      id: "C011123",
-      name: "위승주",
-      userId: "wsj11029",
-      phone: "010-3655-5641",
-      status: "정상",
-      joinDate: "2024-09-03",
-      banEndDate: "-",
-      action: "-",
+      id: "011",
+      reportDate: "2024-11-13",
+      reporterId: "wsj11029",
+      reportedId: "oyatplum",
+      content: "노쇼 신고",
+      status: "처리 전",
+      completedDate: "-",
+      result: "-",
     },
     {
-      id: "C011124",
-      name: "김철수",
-      userId: "kimcs99",
-      phone: "010-2222-3333",
-      status: "정상",
-      joinDate: "2024-07-01",
-      banEndDate: "-",
-      action: "-",
+      id: "042",
+      reportDate: "2024-11-24",
+      reporterId: "wsj11029",
+      reportedId: "kimjuns00",
+      content: "노쇼 신고",
+      status: "처리 전",
+      completedDate: "-",
+      result: "-",
     },
   ];
+
+  const handleInputChange = (index: number, value: string) => {
+    const key = fieldNames[index];
+    setSearchParams((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSearchClick = () => {
+    // 나중에 API 트리거 연동
+  };
 
   return (
     <Container>
@@ -54,8 +64,22 @@ export default function ReportPage() {
           ]}
         />
         <InnerContainer>
-          <SearchBox titles={["신고자 :", "신고 대상 :"]} />
-          <Table columns={columns} data={data} />
+          <SearchBox
+            titles={["신고자 :", "신고 대상 :"]}
+            inputValues={fieldNames.map(
+              (name) => searchParams[name as keyof typeof searchParams]
+            )}
+            onInputChange={handleInputChange}
+            onSearchClick={handleSearchClick}
+          />
+          <Table
+            columns={reportColumns}
+            data={data.map((row) => ({
+              ...row,
+              createdAt: formatDate(row.completedDate),
+            }))}
+            renderCell={renderReportCell}
+          />
         </InnerContainer>
       </ContentContainer>
     </Container>

--- a/src/pages/user/UserMainPage.tsx
+++ b/src/pages/user/UserMainPage.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import styled from "styled-components";
+import SearchBox from "../../components/common/SearchBox";
+import Table from "../../components/common/Table";
+import { useNavigate } from "react-router-dom";
+import { userColumns } from "../../constants/constants";
+import { renderUserCell } from "../../utils/renderUserCell";
+import { formatDate } from "../../utils/formatDate";
+import { UserRow } from "../../types/CommonTypes";
+
+export default function UserMainPage() {
+  const navigate = useNavigate();
+
+  const fieldNames = ["name", "userId"];
+  const [searchParams, setSearchParams] = useState({
+    name: "",
+    userId: "",
+  });
+  // const [searchTrigger, setSearchTrigger] = useState(0);
+
+  const data: UserRow[] = [
+    {
+      id: "wsj11029",
+      userNum: "C011123",
+      name: "위승주",
+      userId: "wsj11029",
+      phone: "010-3655-5641",
+      status: "정상",
+      createdAt: "2025-05-05T15:51:39.535Z",
+      banEndDate: "2025-05-05T15:51:39.535Z",
+    },
+    {
+      id: "kimcs99",
+      userNum: "C011124",
+      name: "김철수",
+      userId: "kimcs99",
+      phone: "010-2222-3333",
+      status: "정상",
+      createdAt: "2025-05-05T15:51:39.535Z",
+      banEndDate: "2025-05-05T15:51:39.535Z",
+    },
+  ];
+
+  const handleInputChange = (index: number, value: string) => {
+    const key = fieldNames[index];
+    setSearchParams((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSearchClick = () => {
+    // setSearchTrigger((prev) => prev + 1);
+    // 나중에 API 연동 시 여기에 트리거 넣는 걸루..
+  };
+
+  const handleRowClick = (id: string) => {
+    navigate(`/user/${id}`);
+  };
+
+  return (
+    <Container>
+      <SearchBox
+        titles={["회원명 :", "회원 ID :"]}
+        inputValues={fieldNames.map(
+          (name) => searchParams[name as keyof typeof searchParams]
+        )}
+        onInputChange={handleInputChange}
+        onSearchClick={handleSearchClick}
+      />
+      <Table
+        columns={userColumns}
+        data={data.map((user) => ({
+          id: user.userId,
+          userNum: user.userNum,
+          name: user.name,
+          userId: user.userId,
+          phone: user.phone,
+          status: user.status,
+          createdAt: formatDate(user.createdAt),
+          banEndDate: formatDate(user.banEndDate),
+        }))}
+        onRowClick={handleRowClick}
+        renderCell={renderUserCell}
+      />
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+  width: 100%;
+`;

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -1,63 +1,10 @@
-import { useState } from "react";
 import styled from "styled-components";
 import DetailHeader from "../../components/common/Header/DetailHeader";
 import SideBar from "../../components/common/SideBar";
-import SearchBox from "../../components/common/SearchBox";
-import Table from "../../components/common/Table";
-import { useNavigate } from "react-router-dom";
-import { userColumns } from "../../constants/constants";
 import AdminHeader from "../../components/common/Header/AdminHeader";
-import { renderUserCell } from "../../utils/renderUserCell";
-import { formatDate } from "../../utils/formatDate";
-import { UserRow } from "../../types/CommonTypes";
+import { Outlet } from "react-router-dom";
 
 export default function UserPage() {
-  const navigate = useNavigate();
-
-  const fieldNames = ["name", "userId"];
-  const [searchParams, setSearchParams] = useState({
-    name: "",
-    userId: "",
-  });
-  // const [searchTrigger, setSearchTrigger] = useState(0);
-
-  const data: UserRow[] = [
-    {
-      id: "wsj11029",
-      userNum: "C011123",
-      name: "위승주",
-      userId: "wsj11029",
-      phone: "010-3655-5641",
-      status: "정상",
-      createdAt: "2025-05-05T15:51:39.535Z",
-      banEndDate: "2025-05-05T15:51:39.535Z",
-    },
-    {
-      id: "kimcs99",
-      userNum: "C011124",
-      name: "김철수",
-      userId: "kimcs99",
-      phone: "010-2222-3333",
-      status: "정상",
-      createdAt: "2025-05-05T15:51:39.535Z",
-      banEndDate: "2025-05-05T15:51:39.535Z",
-    },
-  ];
-
-  const handleInputChange = (index: number, value: string) => {
-    const key = fieldNames[index];
-    setSearchParams((prev) => ({ ...prev, [key]: value }));
-  };
-
-  const handleSearchClick = () => {
-    // setSearchTrigger((prev) => prev + 1);
-    // 나중에 API 연동 시 여기에 트리거 넣는 걸루..
-  };
-
-  const handleRowClick = (id: string) => {
-    navigate(`/user/${id}`);
-  };
-
   return (
     <Container>
       <AdminHeader />
@@ -67,31 +14,7 @@ export default function UserPage() {
           title="회원정보 관리"
           menuItems={[{ text: "회원 조회", path: "/user" }]}
         />
-        <InnerContainer>
-          <SearchBox
-            titles={["회원명 :", "회원 ID :"]}
-            inputValues={fieldNames.map(
-              (name) => searchParams[name as keyof typeof searchParams]
-            )}
-            onInputChange={handleInputChange}
-            onSearchClick={handleSearchClick}
-          />
-          <Table
-            columns={userColumns}
-            data={data.map((user) => ({
-              id: user.userId,
-              userNum: user.userNum,
-              name: user.name,
-              userId: user.userId,
-              phone: user.phone,
-              status: user.status,
-              createdAt: formatDate(user.createdAt),
-              banEndDate: formatDate(user.banEndDate),
-            }))}
-            onRowClick={handleRowClick}
-            renderCell={renderUserCell}
-          />
-        </InnerContainer>
+        <Outlet />
       </ContentContainer>
     </Container>
   );
@@ -108,11 +31,4 @@ const ContentContainer = styled.div`
   align-items: flex-start;
   gap: 4.9rem;
   padding: 3.5rem 5rem 0rem 7.6rem;
-`;
-
-const InnerContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 3.5rem;
-  width: 100%;
 `;

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -1,38 +1,58 @@
+import { useState } from "react";
 import styled from "styled-components";
 import DetailHeader from "../../components/common/Header/DetailHeader";
 import SideBar from "../../components/common/SideBar";
 import SearchBox from "../../components/common/SearchBox";
 import Table from "../../components/common/Table";
-import { UserDataTypes } from "../../types/CommonTypes";
 import { useNavigate } from "react-router-dom";
 import { userColumns } from "../../constants/constants";
 import AdminHeader from "../../components/common/Header/AdminHeader";
+import { renderUserCell } from "../../utils/renderUserCell";
+import { formatDate } from "../../utils/formatDate";
+import { UserRow } from "../../types/CommonTypes";
 
 export default function UserPage() {
   const navigate = useNavigate();
 
-  const data: UserDataTypes[] = [
+  const fieldNames = ["name", "userId"];
+  const [searchParams, setSearchParams] = useState({
+    name: "",
+    userId: "",
+  });
+  // const [searchTrigger, setSearchTrigger] = useState(0);
+
+  const data: UserRow[] = [
     {
-      id: "C011123",
+      id: "wsj11029",
+      userNum: "C011123",
       name: "위승주",
       userId: "wsj11029",
       phone: "010-3655-5641",
       status: "정상",
-      joinDate: "2024-09-03",
-      banEndDate: "-",
-      action: "-",
+      createdAt: "2025-05-05T15:51:39.535Z",
+      banEndDate: "2025-05-05T15:51:39.535Z",
     },
     {
-      id: "C011124",
+      id: "kimcs99",
+      userNum: "C011124",
       name: "김철수",
       userId: "kimcs99",
       phone: "010-2222-3333",
       status: "정상",
-      joinDate: "2024-07-01",
-      banEndDate: "-",
-      action: "-",
+      createdAt: "2025-05-05T15:51:39.535Z",
+      banEndDate: "2025-05-05T15:51:39.535Z",
     },
   ];
+
+  const handleInputChange = (index: number, value: string) => {
+    const key = fieldNames[index];
+    setSearchParams((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSearchClick = () => {
+    // setSearchTrigger((prev) => prev + 1);
+    // 나중에 API 연동 시 여기에 트리거 넣는 걸루..
+  };
 
   const handleRowClick = (id: string) => {
     navigate(`/user/${id}`);
@@ -48,11 +68,28 @@ export default function UserPage() {
           menuItems={[{ text: "회원 조회", path: "/user" }]}
         />
         <InnerContainer>
-          <SearchBox titles={["회원명 :", "회원 ID :"]} />
+          <SearchBox
+            titles={["회원명 :", "회원 ID :"]}
+            inputValues={fieldNames.map(
+              (name) => searchParams[name as keyof typeof searchParams]
+            )}
+            onInputChange={handleInputChange}
+            onSearchClick={handleSearchClick}
+          />
           <Table
             columns={userColumns}
-            data={data}
+            data={data.map((user) => ({
+              id: user.userId,
+              userNum: user.userNum,
+              name: user.name,
+              userId: user.userId,
+              phone: user.phone,
+              status: user.status,
+              createdAt: formatDate(user.createdAt),
+              banEndDate: formatDate(user.banEndDate),
+            }))}
             onRowClick={handleRowClick}
+            renderCell={renderUserCell}
           />
         </InnerContainer>
       </ContentContainer>

--- a/src/pages/wine/AddWinePage.tsx
+++ b/src/pages/wine/AddWinePage.tsx
@@ -1,42 +1,5 @@
-import styled from "styled-components";
-import DetailHeader from "../../components/common/Header/DetailHeader";
-import SideBar from "../../components/common/SideBar";
-import WineDetailContent from "./WineDetailContent";
-import AdminHeader from "../../components/common/Header/AdminHeader";
+import WineDetailContent from "../../components/WineDetailContent";
 
 export default function AddWinePage() {
-  return (
-    <Container>
-      <AdminHeader />
-      <DetailHeader />
-      <ContentContainer>
-        <SideBar
-          title="와인정보 관리"
-          menuItems={[
-            { text: "등록된 와인 리스트", path: "/wine" },
-            { text: "와인 추가", path: "/wine/add" },
-          ]}
-        />
-        <StyledWrapper>
-          <WineDetailContent />
-        </StyledWrapper>
-      </ContentContainer>
-    </Container>
-  );
+  return <WineDetailContent />;
 }
-
-const Container = styled.div`
-  width: 100%;
-  height: 100%;
-  background-color: ${({ theme }) => theme.colors.white};
-`;
-
-const ContentContainer = styled.div`
-  padding: 3.5rem 5rem 0rem 7.6rem;
-  display: flex;
-  align-items: flex-start;
-`;
-
-const StyledWrapper = styled.div`
-  margin-left: 5.7rem;
-`;

--- a/src/pages/wine/AddWinePage.tsx
+++ b/src/pages/wine/AddWinePage.tsx
@@ -4,7 +4,7 @@ import SideBar from "../../components/common/SideBar";
 import WineDetailContent from "./WineDetailContent";
 import AdminHeader from "../../components/common/Header/AdminHeader";
 
-export default function WineAddPage() {
+export default function AddWinePage() {
   return (
     <Container>
       <AdminHeader />

--- a/src/pages/wine/WineDetailPage.tsx
+++ b/src/pages/wine/WineDetailPage.tsx
@@ -3,22 +3,24 @@ import DetailHeader from "../../components/common/Header/DetailHeader";
 import SideBar from "../../components/common/SideBar";
 import Table from "../../components/common/Table";
 import { wineColumns } from "../../constants/constants";
-import { TitledWineDataTypes } from "../../types/CommonTypes";
 import WineDetailContent from "./WineDetailContent";
 import AdminHeader from "../../components/common/Header/AdminHeader";
+import { renderWineCell } from "../../utils/renderWineCell";
+import { WineRow } from "../../types/CommonTypes";
 
 export default function WineDetailPage() {
-  const titleData: TitledWineDataTypes[] = [
+  const titleData: WineRow[] = [
     //추후 api로 개별 와인 조회 예정이라 정적 데이터 -> id 조회 api 예상/예정
     {
       id: "102391",
+      wineId: "102391",
       name: "루이 로드레 크리스탈 2014",
       sort: "스파클링",
       region: "상파뉴",
       country: "프랑스",
-      date: "2024-09-03",
-      action1: "-",
-      action2: "-",
+      variety:
+        "산지오베제 30%, 알리아니코 30%, 카베르네 소비뇽 30%, 네로 다볼라 10%",
+      createdAt: "2025-02-07T15:00:0",
     },
   ];
 
@@ -35,7 +37,11 @@ export default function WineDetailPage() {
           ]}
         />
         <InnerContainer>
-          <Table columns={wineColumns} data={titleData} />
+          <Table
+            columns={wineColumns}
+            data={titleData}
+            renderCell={renderWineCell}
+          />
           <StyledWrapper>
             <WineDetailContent />
           </StyledWrapper>

--- a/src/pages/wine/WineDetailPage.tsx
+++ b/src/pages/wine/WineDetailPage.tsx
@@ -1,10 +1,7 @@
 import styled from "styled-components";
-import DetailHeader from "../../components/common/Header/DetailHeader";
-import SideBar from "../../components/common/SideBar";
 import Table from "../../components/common/Table";
 import { wineColumns } from "../../constants/constants";
-import WineDetailContent from "./WineDetailContent";
-import AdminHeader from "../../components/common/Header/AdminHeader";
+import WineDetailContent from "../../components/WineDetailContent";
 import { renderWineCell } from "../../utils/renderWineCell";
 import { WineRow } from "../../types/CommonTypes";
 
@@ -25,44 +22,18 @@ export default function WineDetailPage() {
   ];
 
   return (
-    <Container>
-      <AdminHeader />
-      <DetailHeader />
-      <ContentContainer>
-        <SideBar
-          title="와인정보 관리"
-          menuItems={[
-            { text: "등록된 와인 리스트", path: "/wine" },
-            { text: "와인 추가", path: "/wine/add" },
-          ]}
-        />
-        <InnerContainer>
-          <Table
-            columns={wineColumns}
-            data={titleData}
-            renderCell={renderWineCell}
-          />
-          <StyledWrapper>
-            <WineDetailContent />
-          </StyledWrapper>
-        </InnerContainer>
-      </ContentContainer>
-    </Container>
+    <InnerContainer>
+      <Table
+        columns={wineColumns}
+        data={titleData}
+        renderCell={renderWineCell}
+      />
+      <StyledWrapper>
+        <WineDetailContent />
+      </StyledWrapper>
+    </InnerContainer>
   );
 }
-
-const Container = styled.div`
-  width: 100%;
-  height: 100%;
-  background-color: ${({ theme }) => theme.colors.white};
-`;
-
-const ContentContainer = styled.div`
-  display: flex;
-  align-items: flex-start;
-  gap: 4.9rem;
-  padding: 3.5rem 5rem 0rem 7.6rem;
-`;
 
 const InnerContainer = styled.div`
   display: flex;

--- a/src/pages/wine/WineMainPage.tsx
+++ b/src/pages/wine/WineMainPage.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import styled from "styled-components";
+import SearchBox from "../../components/common/SearchBox";
+import Table from "../../components/common/Table";
+import { useNavigate } from "react-router-dom";
+import { wineColumns } from "../../constants/constants";
+import { useGetWineSearch } from "../../hooks/useGetWineSearch";
+import { formatDate } from "../../utils/formatDate";
+import Pagination from "../../components/common/Pagination";
+import { renderWineCell } from "../../utils/renderWineCell";
+
+export default function WineMainPage() {
+  const navigate = useNavigate();
+
+  const fieldNames = ["searchName", "wineSort", "wineVariety", "wineCountry"];
+  const [searchTrigger, setSearchTrigger] = useState(0);
+  const [page, setPage] = useState(0);
+
+  // state를 필드 이름 기반으로 관리
+  const [searchParams, setSearchParams] = useState({
+    searchName: "",
+    wineSort: "",
+    wineVariety: "",
+    wineCountry: "",
+  });
+
+  const { data: WineData } = useGetWineSearch({
+    ...searchParams,
+    page: page,
+    size: 7,
+    sort: "name,ASC",
+    trigger: searchTrigger,
+  });
+
+  const handleInputChange = (index: number, value: string) => {
+    const field = fieldNames[index];
+    setSearchParams((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleSearchClick = () => {
+    setSearchTrigger((prev) => prev + 1);
+  };
+
+  const handleRowClick = (id: string) => {
+    navigate(`/wine/${id}`);
+  };
+
+  if (!WineData) {
+    return <></>;
+  }
+
+  return (
+    <Container>
+      <SearchBox
+        titles={["와인명 :", "종류 :", "품종 :", "생산지 :"]}
+        inputValues={fieldNames.map(
+          (name) => searchParams[name as keyof typeof searchParams]
+        )}
+        onInputChange={handleInputChange}
+        onSearchClick={handleSearchClick}
+      />
+      <Table
+        columns={wineColumns}
+        data={(WineData?.result.content ?? []).map((wine) => ({
+          id: wine.wineId.toString(),
+          wineId: wine.wineId.toString(),
+          name: wine.name,
+          sort: wine.sort,
+          region: wine.region,
+          country: wine.country,
+          variety: wine.variety,
+          createdAt: formatDate(wine.createdAt),
+        }))}
+        onRowClick={handleRowClick}
+        renderCell={renderWineCell}
+      />
+      <Pagination
+        currentPage={page + 1} // 서버는 0부터니까 사용자에게는 1부터 보여주기
+        totalPages={WineData?.result.totalPages || 1}
+        onPageChange={(newPage) => {
+          setPage(newPage - 1); // 사용자는 1페이지부터 누르지만 서버는 0부터니까 -1
+          setSearchTrigger((prev) => prev + 1); // API 다시 요청
+        }}
+      />
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+  width: 100%;
+`;

--- a/src/pages/wine/WinePage.tsx
+++ b/src/pages/wine/WinePage.tsx
@@ -1,60 +1,10 @@
-import { useState } from "react";
 import styled from "styled-components";
 import DetailHeader from "../../components/common/Header/DetailHeader";
 import SideBar from "../../components/common/SideBar";
-import SearchBox from "../../components/common/SearchBox";
-import Table from "../../components/common/Table";
-import { useNavigate } from "react-router-dom";
-import { wineColumns } from "../../constants/constants";
 import AdminHeader from "../../components/common/Header/AdminHeader";
-import { useGetWineSearch } from "../../hooks/useGetWineSearch";
-import { formatDate } from "../../utils/formatDate";
-import Pagination from "../../components/common/Pagination";
-import { renderWineCell } from "../../utils/renderWineCell";
+import { Outlet } from "react-router-dom";
 
 export default function WinePage() {
-  const navigate = useNavigate();
-
-  const fieldNames = ["searchName", "wineSort", "wineVariety", "wineCountry"];
-  const [searchTrigger, setSearchTrigger] = useState(0);
-  const [page, setPage] = useState(0);
-
-  // state를 필드 이름 기반으로 관리
-  const [searchParams, setSearchParams] = useState({
-    searchName: "",
-    wineSort: "",
-    wineVariety: "",
-    wineCountry: "",
-  });
-
-  const { data: WineData } = useGetWineSearch({
-    ...searchParams,
-    page: page,
-    size: 7,
-    sort: "name,ASC",
-    trigger: searchTrigger,
-  });
-
-  const handleInputChange = (index: number, value: string) => {
-    const field = fieldNames[index];
-    setSearchParams((prev) => ({
-      ...prev,
-      [field]: value,
-    }));
-  };
-
-  const handleSearchClick = () => {
-    setSearchTrigger((prev) => prev + 1);
-  };
-
-  const handleRowClick = (id: string) => {
-    navigate(`/wine/${id}`);
-  };
-
-  if (!WineData) {
-    return <></>;
-  }
-
   return (
     <Container>
       <AdminHeader />
@@ -67,39 +17,7 @@ export default function WinePage() {
             { text: "와인 추가", path: "/wine/add" },
           ]}
         />
-        <InnerContainer>
-          <SearchBox
-            titles={["와인명 :", "종류 :", "품종 :", "생산지 :"]}
-            inputValues={fieldNames.map(
-              (name) => searchParams[name as keyof typeof searchParams]
-            )}
-            onInputChange={handleInputChange}
-            onSearchClick={handleSearchClick}
-          />
-          <Table
-            columns={wineColumns}
-            data={(WineData?.result.content ?? []).map((wine) => ({
-              id: wine.wineId.toString(),
-              wineId: wine.wineId.toString(),
-              name: wine.name,
-              sort: wine.sort,
-              region: wine.region,
-              country: wine.country,
-              variety: wine.variety,
-              createdAt: formatDate(wine.createdAt),
-            }))}
-            onRowClick={handleRowClick}
-            renderCell={renderWineCell}
-          />
-          <Pagination
-            currentPage={page + 1} // 서버는 0부터니까 사용자에게는 1부터 보여주기
-            totalPages={WineData?.result.totalPages || 1}
-            onPageChange={(newPage) => {
-              setPage(newPage - 1); // 사용자는 1페이지부터 누르지만 서버는 0부터니까 -1
-              setSearchTrigger((prev) => prev + 1); // API 다시 요청
-            }}
-          />
-        </InnerContainer>
+        <Outlet />
       </ContentContainer>
     </Container>
   );
@@ -116,11 +34,4 @@ const ContentContainer = styled.div`
   align-items: flex-start;
   gap: 4.9rem;
   padding: 3.5rem 5rem 0rem 7.6rem;
-`;
-
-const InnerContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 3.5rem;
-  width: 100%;
 `;

--- a/src/pages/wine/WinePage.tsx
+++ b/src/pages/wine/WinePage.tsx
@@ -10,6 +10,7 @@ import AdminHeader from "../../components/common/Header/AdminHeader";
 import { useGetWineSearch } from "../../hooks/useGetWineSearch";
 import { formatDate } from "../../utils/formatDate";
 import Pagination from "../../components/common/Pagination";
+import { renderWineCell } from "../../utils/renderWineCell";
 
 export default function WinePage() {
   const navigate = useNavigate();
@@ -78,15 +79,17 @@ export default function WinePage() {
           <Table
             columns={wineColumns}
             data={(WineData?.result.content ?? []).map((wine) => ({
-              id: wine.wineId.toString(), // 클릭용
-              wineId: wine.wineId.toString(), // 출력용
+              id: wine.wineId.toString(),
+              wineId: wine.wineId.toString(),
               name: wine.name,
               sort: wine.sort,
-              variety: wine.variety,
+              region: wine.region,
               country: wine.country,
+              variety: wine.variety,
               createdAt: formatDate(wine.createdAt),
             }))}
             onRowClick={handleRowClick}
+            renderCell={renderWineCell}
           />
           <Pagination
             currentPage={page + 1} // 서버는 0부터니까 사용자에게는 1부터 보여주기

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,8 +4,10 @@ import LoginPage from "./pages/login/LoginPage";
 import ClassPage from "./pages/class/ClassPage";
 import ClassMemberPage from "./pages/class/ClassMemberPage";
 import WinePage from "./pages/wine/WinePage";
+import WineMainPage from "./pages/wine/WineMainPage";
 import AddWinePage from "./pages/wine/AddWinePage";
 import UserPage from "./pages/user/UserPage";
+import UserMainPage from "./pages/user/UserMainPage";
 import ReportPage from "./pages/report/ReportPage";
 import NoshowReportPage from "./pages/report/NoshowReportPage";
 import CompletedReportPage from "./pages/report/CompletedReportPage";
@@ -32,6 +34,7 @@ export const router = createBrowserRouter([
     path: "/wine",
     element: <WinePage />,
     children: [
+      { index: true, element: <WineMainPage /> }, // /wine
       { path: "add", element: <AddWinePage /> }, // /wine/add
       { path: ":id", element: <WineDetailPage /> }, // /wine/:id
     ],
@@ -40,6 +43,7 @@ export const router = createBrowserRouter([
     path: "/user",
     element: <UserPage />,
     children: [
+      { index: true, element: <UserMainPage /> }, // /user
       { path: ":id", element: <UserDetailPage /> }, // /user/:id
     ],
   },

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -52,3 +52,14 @@ export interface UserRow {
   createdAt: string;
   banEndDate: string;
 }
+
+export interface ReportRow {
+  id: string;
+  reportDate: string;
+  reporterId: string;
+  reportedId: string;
+  content: string;
+  status: string;
+  completedDate: string;
+  result: string;
+}

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -41,3 +41,14 @@ export interface WineRow {
   variety: string;
   createdAt: string;
 }
+
+export interface UserRow {
+  id: string;
+  userNum: string;
+  name: string;
+  userId: string;
+  phone: string;
+  status: string;
+  createdAt: string;
+  banEndDate: string;
+}

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -13,17 +13,6 @@ export interface WineDataTypes {
   action2: string;
 }
 
-export interface TitledWineDataTypes {
-  id: string;
-  name: string;
-  sort: string;
-  region: string;
-  country: string;
-  date: string;
-  action1: string;
-  action2: string;
-}
-
 export interface UserDataTypes {
   id: string;
   name: string;
@@ -47,7 +36,8 @@ export interface WineRow {
   wineId: string;
   name: string;
   sort: string;
-  variety: string;
+  region: string;
   country: string;
+  variety: string;
   createdAt: string;
 }

--- a/src/utils/renderReportCell.ts
+++ b/src/utils/renderReportCell.ts
@@ -1,0 +1,28 @@
+import { ReportRow } from "../types/CommonTypes";
+
+// column 이름과 row 필드를 매칭하는 함수
+export function renderReportCell(
+  row: ReportRow,
+  column: string
+): React.ReactNode {
+  switch (column) {
+    case "접수 번호":
+      return row.id;
+    case "신고 날짜":
+      return row.reportDate;
+    case "신고자 ID":
+      return row.reporterId;
+    case "신고대상 ID":
+      return row.reportedId;
+    case "신고내용":
+      return row.content;
+    case "처리상태":
+      return row.status;
+    case "처리완료일":
+      return row.completedDate;
+    case "처리결과":
+      return row.result;
+    default:
+      return "";
+  }
+}

--- a/src/utils/renderUserCell.ts
+++ b/src/utils/renderUserCell.ts
@@ -1,0 +1,23 @@
+import { UserRow } from "../types/CommonTypes";
+
+// column 이름과 row 필드를 매칭하는 함수
+export function renderUserCell(row: UserRow, column: string): React.ReactNode {
+  switch (column) {
+    case "회원 번호":
+      return row.userNum;
+    case "회원명":
+      return row.name;
+    case "회원 ID":
+      return row.userId;
+    case "전화번호":
+      return row.phone;
+    case "회원 상태":
+      return row.status;
+    case "가입일":
+      return row.createdAt;
+    case "정지 마감일":
+      return row.banEndDate;
+    default:
+      return "-"; // 매칭되는게 없으면 -
+  }
+}

--- a/src/utils/renderWineCell.ts
+++ b/src/utils/renderWineCell.ts
@@ -1,7 +1,7 @@
 import { WineRow } from "../types/CommonTypes";
 
 // column 이름과 row 필드를 매칭하는 함수
-export function renderCell(row: WineRow, column: string) {
+export function renderWineCell(row: WineRow, column: string): React.ReactNode {
   switch (column) {
     case "와인 번호":
       return row.wineId;
@@ -10,9 +10,11 @@ export function renderCell(row: WineRow, column: string) {
     case "종류":
       return row.sort;
     case "지역":
-      return row.variety;
+      return row.region;
     case "생산지(국가)":
       return row.country;
+    case "품종":
+      return row.variety;
     case "등록일":
       return row.createdAt;
     default:

--- a/src/utils/renderWineCell.ts
+++ b/src/utils/renderWineCell.ts
@@ -18,6 +18,6 @@ export function renderWineCell(row: WineRow, column: string): React.ReactNode {
     case "등록일":
       return row.createdAt;
     default:
-      return ""; // 매칭되는게 없으면 빈칸
+      return "-"; // 매칭되는게 없으면 -
   }
 }


### PR DESCRIPTION
## Related Issues

- close #18 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 오류 수정

## ✅ 변경 사항 in Detail

수정한 파일이 많아서 놀랐겠지만...... 음 api 연결을 와인페이지만 하면 된다고 해서 생각없이 와인페이지 table만 수정해둔 걸 고치느라 파일 이것저것 건드렸다............

- [x] 기존에 와인페이지 기준으로 작성한 Table 컴포넌트를 수정하여 각 페이지 공통 테이블 구조 적용했엉
  - `renderWineCell`, `renderUserCell`, `renderReportCell ` 셀 렌더링 함수 분리
  - types 폴더에 `UserRow`, `ReportRow` 따로 추가

- [x] 자식 페이지가 정상적으로 렌더링되도록 `<Outlet />`을 추가했어!
  - WinePage에 헤더, 사이드바까지 넣어서 공통 레이아웃을 만들어서 WineMainPage, WineDetailPage ... 이렇게 하위 페이지가 되게끔 했엉
  - 마찬가지로 UserPage, ReportPage도 공통 레이아웃은 분리했어!

